### PR TITLE
JOML-conversion compatibility fix for Terasology PR #3917

### DIFF
--- a/src/main/java/org/terasology/weatherManager/systems/EmitWeatherParticleSystem.java
+++ b/src/main/java/org/terasology/weatherManager/systems/EmitWeatherParticleSystem.java
@@ -26,6 +26,7 @@ import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.characters.events.DeathEvent;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.logic.players.event.OnPlayerSpawnedEvent;
+import org.terasology.math.JomlUtil;
 import org.terasology.math.geom.Vector2f;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.network.events.DisconnectedEvent;
@@ -312,8 +313,8 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
                     if (!particleSpawners.containsKey(new Vector2f(locEmitter.x, locEmitter.z))) {
                         EntityBuilder builder = entityManager.newBuilder(prefabName);
                         builder.getComponent(LocationComponent.class).setWorldPosition(locEmitter);
-                        builder.getComponent(VelocityRangeGeneratorComponent.class).minVelocity.set(minVelocity);
-                        builder.getComponent(VelocityRangeGeneratorComponent.class).maxVelocity.set(maxVelocity);
+                        builder.getComponent(VelocityRangeGeneratorComponent.class).minVelocity.set(JomlUtil.from(minVelocity));
+                        builder.getComponent(VelocityRangeGeneratorComponent.class).maxVelocity.set(JomlUtil.from(maxVelocity));
                         builder.setPersistent(true);
                         EntityRef ref = builder.build();
                         particleSpawners.put(new Vector2f(locEmitter.x, locEmitter.z), ref);
@@ -375,8 +376,8 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
 
                         EntityBuilder builder = entityManager.newBuilder(prefabName);
 
-                        builder.getComponent(VelocityRangeGeneratorComponent.class).minVelocity.set(minVelocity);
-                        builder.getComponent(VelocityRangeGeneratorComponent.class).maxVelocity.set(maxVelocity);
+                        builder.getComponent(VelocityRangeGeneratorComponent.class).minVelocity.set(JomlUtil.from(minVelocity));
+                        builder.getComponent(VelocityRangeGeneratorComponent.class).maxVelocity.set(JomlUtil.from(maxVelocity));
                         builder.getComponent(LocationComponent.class).setWorldPosition(locEmitter);
                         builder.setPersistent(true);
 


### PR DESCRIPTION
This PR fixes the module's engine compatibility with the JOML-conversion related changes, done in PR #[3917](https://github.com/MovingBlocks/Terasology/pull/3917).

It should be merged after #3917 has been successfully merged.
# Test
Start a new game with the WeatherManager module enabled. It should rain.