### PR TITLE
perf: Performance Optimization

### DIFF
--- a/assets/prefabs/particleEffects/hail.prefab
+++ b/assets/prefabs/particleEffects/hail.prefab
@@ -4,8 +4,8 @@
     "texture": "WeatherManager:hail"
   },
   "energyRangeGenerator": {
-    "minEnergy": 3,
-    "maxEnergy": 3
+    "minEnergy": 4,
+    "maxEnergy": 4
   },
   "scaleRangeGenerator": {
     "minScale": [1, 1, 1],
@@ -19,7 +19,7 @@
   "particleEmitter": {
     "spawnRateMax": 2,
     "spawnRateMin": 1,
-    "maxParticles": 2000,
+    "maxParticles": 2200,
     "particleCollision": true,
     "destroyEntityWhenDead": true
   },

--- a/assets/prefabs/particleEffects/hail.prefab
+++ b/assets/prefabs/particleEffects/hail.prefab
@@ -19,7 +19,7 @@
   "particleEmitter": {
     "spawnRateMax": 2,
     "spawnRateMin": 1,
-    "maxParticles": 2200,
+    "maxParticles": 2500,
     "particleCollision": true,
     "destroyEntityWhenDead": true
   },

--- a/assets/prefabs/particleEffects/hail.prefab
+++ b/assets/prefabs/particleEffects/hail.prefab
@@ -19,7 +19,7 @@
   "particleEmitter": {
     "spawnRateMax": 2,
     "spawnRateMin": 1,
-    "maxParticles": 1000,
+    "maxParticles": 2000,
     "particleCollision": true,
     "destroyEntityWhenDead": true
   },

--- a/assets/prefabs/particleEffects/hail.prefab
+++ b/assets/prefabs/particleEffects/hail.prefab
@@ -4,8 +4,8 @@
     "texture": "WeatherManager:hail"
   },
   "energyRangeGenerator": {
-    "minEnergy": 45,
-    "maxEnergy": 45
+    "minEnergy": 3,
+    "maxEnergy": 3
   },
   "scaleRangeGenerator": {
     "minScale": [1, 1, 1],
@@ -19,7 +19,7 @@
   "particleEmitter": {
     "spawnRateMax": 2,
     "spawnRateMin": 1,
-    "maxParticles": 100,
+    "maxParticles": 1000,
     "particleCollision": true,
     "destroyEntityWhenDead": true
   },

--- a/assets/prefabs/particleEffects/rain.prefab
+++ b/assets/prefabs/particleEffects/rain.prefab
@@ -4,8 +4,8 @@
     "texture": "WeatherManager:rain"
   },
   "energyRangeGenerator": {
-    "minEnergy": 45,
-    "maxEnergy": 45
+    "minEnergy": 3,
+    "maxEnergy": 3
   },
   "scaleRangeGenerator": {
     "minScale": [1, 1, 1],
@@ -19,7 +19,7 @@
   "particleEmitter": {
     "spawnRateMax": 2,
     "spawnRateMin": 1,
-    "maxParticles": 100,
+    "maxParticles": 1000,
     "particleCollision": true,
     "destroyEntityWhenDead": true
   },

--- a/assets/prefabs/particleEffects/rain.prefab
+++ b/assets/prefabs/particleEffects/rain.prefab
@@ -19,7 +19,7 @@
   "particleEmitter": {
     "spawnRateMax": 2,
     "spawnRateMin": 1,
-    "maxParticles": 2200,
+    "maxParticles": 2500,
     "particleCollision": true,
     "destroyEntityWhenDead": true
   },

--- a/assets/prefabs/particleEffects/rain.prefab
+++ b/assets/prefabs/particleEffects/rain.prefab
@@ -4,8 +4,8 @@
     "texture": "WeatherManager:rain"
   },
   "energyRangeGenerator": {
-    "minEnergy": 3,
-    "maxEnergy": 3
+    "minEnergy": 4,
+    "maxEnergy": 4
   },
   "scaleRangeGenerator": {
     "minScale": [1, 1, 1],
@@ -19,7 +19,7 @@
   "particleEmitter": {
     "spawnRateMax": 2,
     "spawnRateMin": 1,
-    "maxParticles": 2000,
+    "maxParticles": 2200,
     "particleCollision": true,
     "destroyEntityWhenDead": true
   },

--- a/assets/prefabs/particleEffects/rain.prefab
+++ b/assets/prefabs/particleEffects/rain.prefab
@@ -19,7 +19,7 @@
   "particleEmitter": {
     "spawnRateMax": 2,
     "spawnRateMin": 1,
-    "maxParticles": 1000,
+    "maxParticles": 2000,
     "particleCollision": true,
     "destroyEntityWhenDead": true
   },

--- a/assets/prefabs/particleEffects/snow.prefab
+++ b/assets/prefabs/particleEffects/snow.prefab
@@ -19,7 +19,7 @@
   "particleEmitter": {
     "spawnRateMax": 2,
     "spawnRateMin": 1,
-    "maxParticles": 2200,
+    "maxParticles": 2500,
     "particleCollision": true,
     "destroyEntityWhenDead": true
   },

--- a/assets/prefabs/particleEffects/snow.prefab
+++ b/assets/prefabs/particleEffects/snow.prefab
@@ -4,8 +4,8 @@
     "texture": "WeatherManager:snow"
   },
   "energyRangeGenerator": {
-    "minEnergy": 3,
-    "maxEnergy": 3
+    "minEnergy": 4,
+    "maxEnergy": 4
   },
   "scaleRangeGenerator": {
     "minScale": [1, 1, 1],
@@ -19,7 +19,7 @@
   "particleEmitter": {
     "spawnRateMax": 2,
     "spawnRateMin": 1,
-    "maxParticles": 2000,
+    "maxParticles": 2200,
     "particleCollision": true,
     "destroyEntityWhenDead": true
   },

--- a/assets/prefabs/particleEffects/snow.prefab
+++ b/assets/prefabs/particleEffects/snow.prefab
@@ -19,7 +19,7 @@
   "particleEmitter": {
     "spawnRateMax": 2,
     "spawnRateMin": 1,
-    "maxParticles": 1000,
+    "maxParticles": 2000,
     "particleCollision": true,
     "destroyEntityWhenDead": true
   },

--- a/assets/prefabs/particleEffects/snow.prefab
+++ b/assets/prefabs/particleEffects/snow.prefab
@@ -4,8 +4,8 @@
     "texture": "WeatherManager:snow"
   },
   "energyRangeGenerator": {
-    "minEnergy": 45,
-    "maxEnergy": 45
+    "minEnergy": 3,
+    "maxEnergy": 3
   },
   "scaleRangeGenerator": {
     "minScale": [1, 1, 1],
@@ -19,7 +19,7 @@
   "particleEmitter": {
     "spawnRateMax": 2,
     "spawnRateMin": 1,
-    "maxParticles": 100,
+    "maxParticles": 1000,
     "particleCollision": true,
     "destroyEntityWhenDead": true
   },

--- a/src/main/java/org/terasology/weatherManager/systems/EmitWeatherParticleSystem.java
+++ b/src/main/java/org/terasology/weatherManager/systems/EmitWeatherParticleSystem.java
@@ -25,6 +25,7 @@ import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.characters.events.DeathEvent;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.logic.players.event.OnPlayerRespawnedEvent;
 import org.terasology.logic.players.event.OnPlayerSpawnedEvent;
 import org.terasology.math.geom.Vector2f;
 import org.terasology.math.geom.Vector3f;
@@ -55,16 +56,15 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
 
     private static final int PARTICLE_AREA_SIZE = 24;
     private static final int PARTICLE_AREA_HALF_SIZE = PARTICLE_AREA_SIZE / 2;
+    private static final float PARTICLE_SPAWN_HEIGHT = PARTICLE_AREA_SIZE / 3f;
     private static final int BUFFER_AMOUNT = 5;
     private static final int CLOUD_HEIGHT = 127;
 
     private String prefabName = SUN;
 
-    private Map<Vector2f, EntityRef> particleSpawners;
-
-    private Map<Vector2f, EntityBuilder> builders;
-
-    private Map<EntityRef, Vector3f> previousLocations;
+    private final Map<Vector2f, EntityRef> particleSpawners = new HashMap<>();
+    private final Map<Vector2f, EntityBuilder> builders = new HashMap<>();
+    private final Map<EntityRef, Vector3f> previousLocations = new HashMap<>();
 
     private boolean particlesMade;
 
@@ -80,10 +80,6 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
     @Override
     public void postBegin() {
         particlesMade = false;
-
-        particleSpawners = new HashMap<>();
-        builders = new HashMap<>();
-        previousLocations = new HashMap<>();
     }
 
     @ReceiveEvent
@@ -92,7 +88,7 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
     }
 
     @ReceiveEvent
-    public void playerRespawned(OnPlayerSpawnedEvent event, EntityRef player) {
+    public void playerRespawned(OnPlayerRespawnedEvent event, EntityRef player) {
         begin(player);
     }
 
@@ -187,7 +183,7 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
         clearEmitters();
     }
 
-     /**
+    /**
      * Moves the visual effects with the player.
      * @param event The MovedEvent.
      * @param character The entity that sent the MoveEvent.
@@ -267,7 +263,7 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
                         }
                     }
                 } else {
-                    Vector3f newPos = new Vector3f(spawnerPosition.x, center.y + PARTICLE_AREA_SIZE / 3f, spawnerPosition.y);
+                    Vector3f newPos = new Vector3f(spawnerPosition.x, center.y + PARTICLE_SPAWN_HEIGHT, spawnerPosition.y);
                     LocationComponent loc = builders.get(spawnerPosition).getComponent(LocationComponent.class);
                     if (!loc.getWorldPosition().equals(newPos)) {
                         builders.get(spawnerPosition).getComponent(LocationComponent.class).setWorldPosition(newPos);
@@ -294,7 +290,7 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
                 for (int j = -PARTICLE_AREA_HALF_SIZE; j < PARTICLE_AREA_HALF_SIZE; j++) {
                     Vector3f emitterPosition = new Vector3f(center);
 
-                    emitterPosition.addY(Math.min(CLOUD_HEIGHT, PARTICLE_AREA_SIZE / 3f));
+                    emitterPosition.addY(Math.min(CLOUD_HEIGHT, PARTICLE_SPAWN_HEIGHT));
 
                     if (x) {
                         if (positive) {
@@ -342,8 +338,8 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
             }
         }
 
-        builders = new HashMap<>();
-        particleSpawners = new HashMap<>();
+        builders.clear();
+        particleSpawners.clear();
     }
 
     /**

--- a/src/main/java/org/terasology/weatherManager/systems/EmitWeatherParticleSystem.java
+++ b/src/main/java/org/terasology/weatherManager/systems/EmitWeatherParticleSystem.java
@@ -78,14 +78,16 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
 
     @ReceiveEvent
     public void playerRespawned(OnPlayerRespawnedEvent event, EntityRef entity) {
-        if (entityIsLocalPlayer(entity) && !currentWeather.equals(SUN))
+        if (entityIsLocalPlayer(entity) && !currentWeather.equals(SUN)) {
             beginParticles();
+        }
     }
 
     @ReceiveEvent
     public void playerDied(DeathEvent event, EntityRef entity) {
-        if (entityIsLocalPlayer(entity))
+        if (entityIsLocalPlayer(entity)) {
             clearEmitters();
+        }
     }
 
     private boolean entityIsLocalPlayer(EntityRef entity) {
@@ -99,8 +101,9 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
      */
     @ReceiveEvent
     public void onStartRainEvent(StartRainEvent event, EntityRef worldEntity) {
-        if (!currentWeather.equals(RAIN))
+        if (!currentWeather.equals(RAIN)) {
             changeWeather(RAIN);
+        }
     }
 
     /**
@@ -110,8 +113,9 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
      */
     @ReceiveEvent
     public void onStartSnowEvent(StartSnowEvent event, EntityRef worldEntity) {
-        if (!currentWeather.equals(SNOW))
+        if (!currentWeather.equals(SNOW)) {
             changeWeather(SNOW);
+        }
     }
 
     /**
@@ -121,16 +125,18 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
      */
     @ReceiveEvent
     public void onStartHailEvent(StartHailEvent event, EntityRef worldEntity) {
-        if (!currentWeather.equals(HAIL))
+        if (!currentWeather.equals(HAIL)) {
             changeWeather(HAIL);
+        }
     }
 
     private void changeWeather(Name targetWeather) {
         clearEmitters();
         currentWeather = targetWeather;
 
-        if (!currentWeather.equals(SUN))
+        if (!currentWeather.equals(SUN)) {
             beginParticles();
+        }
     }
 
     /**
@@ -215,12 +221,14 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
                     emitterBuilder.getComponent(LocationComponent.class).setWorldPosition(emitterPosition);
                     emitterBuilder.setPersistent(false);
 
-                    if (particlePool != null)
+                    if (particlePool != null) {
                         emitterBuilder.getComponent(ParticleEmitterComponent.class).particlePool = particlePool;
+                    }
 
                     EntityRef emitter = emitterBuilder.build();
-                    if (particlePool == null)
+                    if (particlePool == null) {
                         particlePool = emitter.getComponent(ParticleEmitterComponent.class).particlePool;
+                    }
 
                     Location.attachChild(localPlayer.getCharacterEntity(), emitter);
                     emitters.add(emitter);

--- a/src/main/java/org/terasology/weatherManager/systems/EmitWeatherParticleSystem.java
+++ b/src/main/java/org/terasology/weatherManager/systems/EmitWeatherParticleSystem.java
@@ -30,6 +30,7 @@ import org.terasology.logic.players.event.OnPlayerSpawnedEvent;
 import org.terasology.math.geom.Vector2f;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.network.events.DisconnectedEvent;
+import org.terasology.particles.ParticlePool;
 import org.terasology.particles.components.ParticleEmitterComponent;
 import org.terasology.particles.components.generators.VelocityRangeGeneratorComponent;
 import org.terasology.physics.events.MovedEvent;
@@ -365,21 +366,30 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
                 }
                 Vector3f minVelocity = new Vector3f(maxVelocity.x, minDownfall, maxVelocity.z);
 
+                ParticlePool particlePool = null;
+
                 for (int i = -PARTICLE_AREA_HALF_SIZE; i < PARTICLE_AREA_HALF_SIZE; i++) {
                     for (int j = -PARTICLE_AREA_HALF_SIZE; j < PARTICLE_AREA_HALF_SIZE; j++) {
                         Vector3f emitterPosition = new Vector3f(worldPosition);
-                        emitterPosition.add(i, PARTICLE_AREA_SIZE / 3f, j);
+                        emitterPosition.add(i, PARTICLE_SPAWN_HEIGHT, j);
 
-                        EntityBuilder builder = entityManager.newBuilder(prefabName);
+                        EntityBuilder emitterBuilder = entityManager.newBuilder(prefabName);
 
-                        builder.getComponent(VelocityRangeGeneratorComponent.class).minVelocity.set(minVelocity);
-                        builder.getComponent(VelocityRangeGeneratorComponent.class).maxVelocity.set(maxVelocity);
-                        builder.getComponent(LocationComponent.class).setWorldPosition(emitterPosition);
-                        builder.setPersistent(true);
+                        emitterBuilder.getComponent(VelocityRangeGeneratorComponent.class).minVelocity.set(minVelocity);
+                        emitterBuilder.getComponent(VelocityRangeGeneratorComponent.class).maxVelocity.set(maxVelocity);
+                        emitterBuilder.getComponent(LocationComponent.class).setWorldPosition(emitterPosition);
+                        emitterBuilder.setPersistent(true);
 
-                        EntityRef emitter = builder.build();
+                        if (particlePool != null)
+                            emitterBuilder.getComponent(ParticleEmitterComponent.class).particlePool = particlePool;
+
+                        EntityRef emitter = emitterBuilder.build();
+
+                        if (particlePool == null)
+                            particlePool = emitter.getComponent(ParticleEmitterComponent.class).particlePool;
+
                         particleSpawners.put(new Vector2f(emitterPosition.x, emitterPosition.z), emitter);
-                        builders.put(new Vector2f(emitterPosition.x, emitterPosition.z), builder);
+                        builders.put(new Vector2f(emitterPosition.x, emitterPosition.z), emitterBuilder);
                     }
                 }
             }

--- a/src/main/java/org/terasology/weatherManager/systems/EmitWeatherParticleSystem.java
+++ b/src/main/java/org/terasology/weatherManager/systems/EmitWeatherParticleSystem.java
@@ -16,6 +16,8 @@
 
 package org.terasology.weatherManager.systems;
 
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
 import org.terasology.entitySystem.entity.EntityBuilder;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -28,7 +30,6 @@ import org.terasology.logic.location.Location;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.logic.players.LocalPlayer;
 import org.terasology.logic.players.event.OnPlayerRespawnedEvent;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.naming.Name;
 import org.terasology.particles.ParticlePool;
 import org.terasology.particles.components.ParticleEmitterComponent;
@@ -208,17 +209,11 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
                 ParticlePool particlePool = null;
 
                 for (int i = 0; i < PARTICLE_EMITTERS_COUNT; i++) {
-                    float relativeX = (float) random.nextGaussian() * PARTICLE_AREA_HALF_SIZE;
-                    float relativeZ = (float) random.nextGaussian() * PARTICLE_AREA_HALF_SIZE + PARTICLE_AREA_HALF_SIZE / 2f;
-
-                    Vector3f emitterPosition = location.getWorldPosition()
-                            .add(relativeX, PARTICLE_SPAWN_HEIGHT, relativeZ);
-
                     EntityBuilder emitterBuilder = entityManager.newBuilder(currentWeather.toString());
-
-                    emitterBuilder.getComponent(VelocityRangeGeneratorComponent.class).minVelocity.set(minVelocity);
-                    emitterBuilder.getComponent(VelocityRangeGeneratorComponent.class).maxVelocity.set(maxVelocity);
-                    emitterBuilder.getComponent(LocationComponent.class).setWorldPosition(emitterPosition);
+                    emitterBuilder.getComponent(VelocityRangeGeneratorComponent.class)
+                            .minVelocity.set(minVelocity.x, minVelocity.y, minVelocity.z);
+                    emitterBuilder.getComponent(VelocityRangeGeneratorComponent.class)
+                            .maxVelocity.set(maxVelocity.x, maxVelocity.y, maxVelocity.z);
                     emitterBuilder.setPersistent(false);
 
                     if (particlePool != null) {
@@ -230,7 +225,11 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
                         particlePool = emitter.getComponent(ParticleEmitterComponent.class).particlePool;
                     }
 
-                    Location.attachChild(localPlayer.getCharacterEntity(), emitter);
+                    float relativeX = (float) random.nextGaussian() * PARTICLE_AREA_HALF_SIZE;
+                    float relativeZ = (float) random.nextGaussian() * PARTICLE_AREA_HALF_SIZE + PARTICLE_AREA_SIZE / 3f;
+                    Vector3f emitterPosition = new Vector3f(relativeX, PARTICLE_SPAWN_HEIGHT, relativeZ);
+
+                    Location.attachChild(localPlayer.getCharacterEntity(), emitter, emitterPosition, new Quaternionf());
                     emitters.add(emitter);
                 }
             }

--- a/src/main/java/org/terasology/weatherManager/systems/EmitWeatherParticleSystem.java
+++ b/src/main/java/org/terasology/weatherManager/systems/EmitWeatherParticleSystem.java
@@ -37,8 +37,6 @@ import org.terasology.particles.ParticlePool;
 import org.terasology.particles.components.ParticleEmitterComponent;
 import org.terasology.particles.components.generators.VelocityRangeGeneratorComponent;
 import org.terasology.registry.In;
-import org.terasology.utilities.random.FastRandom;
-import org.terasology.utilities.random.Random;
 import org.terasology.weatherManager.events.StartHailEvent;
 import org.terasology.weatherManager.events.StartRainEvent;
 import org.terasology.weatherManager.events.StartSnowEvent;
@@ -50,6 +48,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 
 //TODO: destroy on contact with blocks (water)
 
@@ -61,12 +60,12 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
     private static final Name RAIN = new Name("rain");
     private static final Name HAIL = new Name("hail");
 
-    private static final int PARTICLE_EMITTERS_COUNT = 300;
-    private static final int PARTICLE_AREA_SIZE = 25;
+    private static final int PARTICLE_EMITTERS_COUNT = 500;
+    private static final int PARTICLE_AREA_SIZE = 15;
     private static final int PARTICLE_AREA_HALF_SIZE = PARTICLE_AREA_SIZE / 2;
     private static final float PARTICLE_SPAWN_HEIGHT = 15;
 
-    private static final Random random = new FastRandom();
+    private static final Random random = new Random();
 
     private Name currentWeather = SUN;
 
@@ -257,8 +256,8 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
                 ParticlePool particlePool = null;
 
                 for (int i = 0; i < PARTICLE_EMITTERS_COUNT; i++) {
-                    float relativeX = random.nextFloat() * PARTICLE_AREA_SIZE - PARTICLE_AREA_HALF_SIZE;
-                    float relativeZ = random.nextFloat() * PARTICLE_AREA_SIZE - PARTICLE_AREA_HALF_SIZE / 2f;
+                    float relativeX = (float) random.nextGaussian() * PARTICLE_AREA_HALF_SIZE;
+                    float relativeZ = (float) random.nextGaussian() * PARTICLE_AREA_HALF_SIZE + PARTICLE_AREA_HALF_SIZE / 2f;
 
                     Vector3f emitterPosition = new Vector3f(worldPosition)
                             .add(relativeX, PARTICLE_SPAWN_HEIGHT, relativeZ);

--- a/src/main/java/org/terasology/weatherManager/systems/EmitWeatherParticleSystem.java
+++ b/src/main/java/org/terasology/weatherManager/systems/EmitWeatherParticleSystem.java
@@ -61,8 +61,8 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
     private static final Name RAIN = new Name("rain");
     private static final Name HAIL = new Name("hail");
 
-    private static final int PARTICLE_EMITTERS_COUNT = 100;
-    private static final int PARTICLE_AREA_SIZE = 20;
+    private static final int PARTICLE_EMITTERS_COUNT = 300;
+    private static final int PARTICLE_AREA_SIZE = 25;
     private static final int PARTICLE_AREA_HALF_SIZE = PARTICLE_AREA_SIZE / 2;
     private static final float PARTICLE_SPAWN_HEIGHT = 15;
 

--- a/src/main/java/org/terasology/weatherManager/systems/EmitWeatherParticleSystem.java
+++ b/src/main/java/org/terasology/weatherManager/systems/EmitWeatherParticleSystem.java
@@ -29,6 +29,7 @@ import org.terasology.logic.location.LocationComponent;
 import org.terasology.logic.players.event.OnPlayerRespawnedEvent;
 import org.terasology.logic.players.event.OnPlayerSpawnedEvent;
 import org.terasology.math.geom.Vector3f;
+import org.terasology.naming.Name;
 import org.terasology.network.ClientComponent;
 import org.terasology.network.events.ConnectedEvent;
 import org.terasology.network.events.DisconnectedEvent;
@@ -55,10 +56,10 @@ import java.util.Map;
 @RegisterSystem(RegisterMode.CLIENT)
 public class EmitWeatherParticleSystem extends BaseComponentSystem {
 
-    private static final String SUN = "sunny";
-    private static final String SNOW = "snow";
-    private static final String RAIN = "rain";
-    private static final String HAIL = "hail";
+    private static final Name SUN = new Name("sunny");
+    private static final Name SNOW = new Name("snow");
+    private static final Name RAIN = new Name("rain");
+    private static final Name HAIL = new Name("hail");
 
     private static final int PARTICLE_EMITTERS_COUNT = 100;
     private static final int PARTICLE_AREA_SIZE = 20;
@@ -67,7 +68,7 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
 
     private static final Random random = new FastRandom();
 
-    private String prefabName = SUN;
+    private Name currentWeather = SUN;
 
     private final Map<EntityRef, List<EntityRef>> emittersByParentEntity = new HashMap<>();
 
@@ -121,7 +122,7 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
      * @param player The player whose effects must begin
      */
     private void begin(EntityRef player) {
-        if (!prefabName.equals(SUN)) {
+        if (!currentWeather.equals(SUN)) {
             prepareParticleProperties();
             beginParticles(player);
         }
@@ -134,7 +135,7 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
      */
     @ReceiveEvent
     public void onStartRainEvent(StartRainEvent event, EntityRef worldEntity) {
-        if (!prefabName.equals(RAIN))
+        if (!currentWeather.equals(RAIN))
             changeWeather(RAIN);
     }
 
@@ -145,7 +146,7 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
      */
     @ReceiveEvent
     public void onStartSnowEvent(StartSnowEvent event, EntityRef worldEntity) {
-        if (!prefabName.equals(SNOW))
+        if (!currentWeather.equals(SNOW))
             changeWeather(SNOW);
     }
 
@@ -156,13 +157,13 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
      */
     @ReceiveEvent
     public void onStartHailEvent(StartHailEvent event, EntityRef worldEntity) {
-        if (!prefabName.equals(HAIL))
+        if (!currentWeather.equals(HAIL))
             changeWeather(HAIL);
     }
 
-    private void changeWeather(String weatherPrefab) {
+    private void changeWeather(Name targetWeather) {
         clearAllEmitters();
-        prefabName = weatherPrefab;
+        currentWeather = targetWeather;
         prepareParticleProperties();
         beginParticlesForAllEntities();
     }
@@ -178,7 +179,7 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
      */
     @ReceiveEvent
     public void onStartSunEvent(StartSunEvent event, EntityRef worldEntity) {
-        prefabName = SUN;
+        currentWeather = SUN;
         clearAllEmitters();
     }
 
@@ -262,7 +263,7 @@ public class EmitWeatherParticleSystem extends BaseComponentSystem {
                     Vector3f emitterPosition = new Vector3f(worldPosition)
                             .add(relativeX, PARTICLE_SPAWN_HEIGHT, relativeZ);
 
-                    EntityBuilder emitterBuilder = entityManager.newBuilder(prefabName);
+                    EntityBuilder emitterBuilder = entityManager.newBuilder(currentWeather.toString());
 
                     emitterBuilder.getComponent(VelocityRangeGeneratorComponent.class).minVelocity.set(minVelocity);
                     emitterBuilder.getComponent(VelocityRangeGeneratorComponent.class).maxVelocity.set(maxVelocity);

--- a/src/main/java/org/terasology/weatherManager/systems/WeatherManagerSystem.java
+++ b/src/main/java/org/terasology/weatherManager/systems/WeatherManagerSystem.java
@@ -130,7 +130,7 @@ public class WeatherManagerSystem extends BaseComponentSystem {
         triggerEvents();
 
         long length = DoubleMath.roundToLong(current.duration, RoundingMode.HALF_UP);
-        delayManager.addDelayedAction(weatherEntity, "Weather", length);
+        delayManager.addDelayedAction(weatherEntity, "RandomWeather", length);
     }
 
     /**
@@ -145,8 +145,6 @@ public class WeatherManagerSystem extends BaseComponentSystem {
         currentWeather = current.condition.downfallCondition.getDownfallValues().type;
         severity = current.condition.downfallCondition.getDownfallValues().amount;
         currentWind = current.condition.wind;
-
-        triggerEvents();
     }
 
 //    private void makeClientsSimulationCarriers() {
@@ -160,11 +158,12 @@ public class WeatherManagerSystem extends BaseComponentSystem {
     @ReceiveEvent
     public void onTimeEvent(DelayedActionTriggeredEvent event, EntityRef worldEntity) {
 
-        current = weatherConditionProvider.getNext();
-
-        currentWeather = current.condition.downfallCondition.getDownfallValues().type;
-        severity = current.condition.downfallCondition.getDownfallValues().amount;
-        currentWind = current.condition.wind;
+        if (event.getActionId().equals("RandomWeather")) {
+            current = weatherConditionProvider.getNext();
+            currentWeather = current.condition.downfallCondition.getDownfallValues().type;
+            severity = current.condition.downfallCondition.getDownfallValues().amount;
+            currentWind = current.condition.wind;
+        }
 
         triggerEvents();
 
@@ -219,7 +218,7 @@ public class WeatherManagerSystem extends BaseComponentSystem {
 
     @Override
     public void postSave() {
-     triggerEvents();
+        triggerEvents();
     }
 
     public DownfallCondition.DownfallType getCurrentWeather() {

--- a/src/main/java/org/terasology/weatherManager/systems/WeatherManagerSystem.java
+++ b/src/main/java/org/terasology/weatherManager/systems/WeatherManagerSystem.java
@@ -24,10 +24,12 @@ import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
 import org.terasology.logic.console.commandSystem.annotations.Command;
 import org.terasology.logic.console.commandSystem.annotations.CommandParam;
 import org.terasology.logic.delay.DelayManager;
 import org.terasology.logic.delay.DelayedActionTriggeredEvent;
+import org.terasology.logic.players.LocalPlayer;
 import org.terasology.math.geom.Vector2f;
 import org.terasology.registry.In;
 import org.terasology.registry.Share;
@@ -46,7 +48,7 @@ import java.util.Random;
 
 @RegisterSystem(RegisterMode.AUTHORITY)
 @Share(WeatherManagerSystem.class)
-public class WeatherManagerSystem extends BaseComponentSystem {
+public class WeatherManagerSystem extends BaseComponentSystem implements UpdateSubscriberSystem {
 
     private Vector2f currentWind;
     private Severity severity;
@@ -68,6 +70,9 @@ public class WeatherManagerSystem extends BaseComponentSystem {
 
     @In
     private WorldTime worldTime;
+
+    @In
+    private LocalPlayer localPlayer;
 
     @Command(shortDescription = "Make it rain", helpText = "Changes the weather to raining for some time")
     public String makeRain(@CommandParam(value = "time") int time) {
@@ -115,22 +120,30 @@ public class WeatherManagerSystem extends BaseComponentSystem {
     }
 
     @Override
-    public void postBegin() {
+    public void update(float delta) {
+        if (localPlayer.isValid()) {
+            if (weatherEntity == null) {
+                weatherEntity = entityManager.create();
 
+                triggerEvents();
+
+                long length = DoubleMath.roundToLong(current.duration, RoundingMode.HALF_UP);
+                delayManager.addDelayedAction(weatherEntity, "RandomWeather", length);
+
+                logger.info("weather activated");
+            }
+        }
+    }
+
+    @Override
+    public void postBegin() {
         float avglength = WorldTime.DAY_LENGTH / 480.0f;// / 48.0f; // worldTime.getTimeRate(); -- not available for modules
         weatherConditionProvider = new MarkovChainWeatherGenerator(12354, avglength);
         current = weatherConditionProvider.getNext();
 
-        weatherEntity = entityManager.create();
-
         currentWeather = current.condition.downfallCondition.getDownfallValues().type;
         severity = current.condition.downfallCondition.getDownfallValues().amount;
         currentWind = current.condition.wind;
-
-        triggerEvents();
-
-        long length = DoubleMath.roundToLong(current.duration, RoundingMode.HALF_UP);
-        delayManager.addDelayedAction(weatherEntity, "RandomWeather", length);
     }
 
     /**


### PR DESCRIPTION
This PR addresses the module's performance issues (fixes #8).

Instead of using a particle pool for every raindrop emitter, we are now using a single particle pool, shared among all raindrop emitters.
Lots of new emitters have been allocated every frame the player moved. Now they are created once and follow the player around passively by being attached to the player entity as its children.

Allocation only happens in case the weather changes, so most of the time the module should be allocation free. The next thing that needs to be improved is the rendering of particle pools in the engine. (partilces in a single pool should be rendered at once)

# Test
Start a new game with the WeatherManager module activated. It should rain and the performance should noticeably better than before.

This PR depends on MovingBlocks/Terasology [#3939](https://github.com/MovingBlocks/Terasology/pull/3939)